### PR TITLE
feat: support reactive attributes and preferredLocale

### DIFF
--- a/.changeset/reactive-attributes.md
+++ b/.changeset/reactive-attributes.md
@@ -1,0 +1,5 @@
+---
+'croct-nanostores': minor
+---
+
+Support Nanostores atoms inside `attributes` at any nesting level and accept `ReadableAtom<string>` for `preferredLocale`. Content automatically refreshes whenever any embedded atom updates.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Croct Nanostores bridges [Croct](https://croct.com)'s personalization engine wit
 - **Type-safe** — Full TypeScript support with [Croct's type generation](https://docs.croct.com/reference/cli). Slot IDs, fallback content, and component props are all validated at compile time.
 - **Fault-tolerant** — Atoms always hold renderable content. Fetches fail silently to your fallback; loaded content is never lost on refresh errors.
 - **Auto-refreshing** — Content can update automatically when user behavior changes (sign-in, profile update, cart modification, and more). Enable the `auto-refresh-atom` plugin when initializing Croct to opt in.
+- **Reactive attributes** — Use Nanostores atoms anywhere in the `attributes` object and content refreshes automatically whenever any of them update — ideal for currency pickers, user segments, or any dynamic context.
 - **Persistent** — Content is cached in `localStorage` by default, so returning users see personalized content instantly.
 
 ## Quick start

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@croct/json": "^2.1.0",
-        "@inox-tools/utils": "^0.8.1",
+        "@inox-tools/utils": "^1.0.0",
         "@nanostores/persistent": "^1.3.3",
         "nanostores": "^1.1.0",
       },
@@ -1597,19 +1597,19 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.8.8", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.8", "turbo-darwin-arm64": "2.8.8", "turbo-linux-64": "2.8.8", "turbo-linux-arm64": "2.8.8", "turbo-windows-64": "2.8.8", "turbo-windows-arm64": "2.8.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wP+axjWAKzYfZ7bghuggVST9bX4j5cn3NPMU9NPQqtwaUKL9n9JOnWWBIc9gdrEma1aViYR73EoPjDEpVq+liQ=="],
+    "turbo": ["turbo@2.8.9", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.9", "turbo-darwin-arm64": "2.8.9", "turbo-linux-64": "2.8.9", "turbo-linux-arm64": "2.8.9", "turbo-windows-64": "2.8.9", "turbo-windows-arm64": "2.8.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-G+Mq8VVQAlpz/0HTsxiNNk/xywaHGl+dk1oiBREgOEVCCDjXInDlONWUn5srRnC9s5tdHTFD1bx1N19eR4hI+g=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.8.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-7R/XRAleyNB8nIJuenRpS7EnmCM/kYFgcG1rW3F5DF57Nl4WyBO3DzxqwooRheuoXDD1UsJvDse0yRufgxjClA=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.8.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-KnCw1ZI9KTnEAhdI9avZrnZ/z4wsM++flMA1w8s8PKOqi5daGpFV36qoPafg4S8TmYMe52JPWEoFr0L+lQ5JIw=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.8.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-whpveO0w/dMcgQ0zFrzqK76mG2W+RBQ/pKIpW+sEvNr+T4UcYd2gZpfV2euehJLvdeFErWgW74dIt/MFfkG1bA=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.8.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CbD5Y2NKJKBXTOZ7z7Cc7vGlFPZkYjApA7ri9lH4iFwKV1X7MoZswh9gyRLetXYWImVX1BqIvP8KftulJg/wIA=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.8.8", "", { "os": "linux", "cpu": "x64" }, "sha512-BISkcKk+5/Dh11q+YhdQIGONXmdlQ6LY0iQ+GBIK7QOBAJyJFKmKvUeAeMdWGXOa3sImz2oZ6u2StyR+0Y/VVA=="],
+    "turbo-linux-64": ["turbo-linux-64@2.8.9", "", { "os": "linux", "cpu": "x64" }, "sha512-OXC9HdCtsHvyH+5KUoH8ds+p5WU13vdif0OPbsFzZca4cUXMwKA3HWwUuCgQetk0iAE4cscXpi/t8A263n3VTg=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.8.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-B+DQWWtM3O+AexFF4aYucT0MvvnQOW4n5y9LA5h3Zc3Lpj10yl9K4dEBzJvMVQ2jTkCRNAvA8q9G3EjqmGmGGA=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.8.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-yI5n8jNXiFA6+CxnXG0gO7h5ZF1+19K8uO3/kXPQmyl37AdiA7ehKJQOvf9OPAnmkGDHcF2HSCPltabERNRmug=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.8.8", "", { "os": "win32", "cpu": "x64" }, "sha512-KP5TRVrmVnrxDyvERvQq7VXu+h5AiEiBwyr90YsRuYy/Z5zLz8hrNZXejTyUR17xmnuI+RbUSxrQlfmPnxiW1A=="],
+    "turbo-windows-64": ["turbo-windows-64@2.8.9", "", { "os": "win32", "cpu": "x64" }, "sha512-/OztzeGftJAg258M/9vK2ZCkUKUzqrWXJIikiD2pm8TlqHcIYUmepDbyZSDfOiUjMy6NzrLFahpNLnY7b5vNgg=="],
 
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.8.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-X45sTOksR8iidk+PZUXpNcfEkOhGCTS2p2J8nSUExr1v7u3T4FixwplzliuWmG7QTPGJapAwItzHbi+d/9ckNQ=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.8.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-xZ2VTwVTjIqpFZKN4UBxDHCPM3oJ2J5cpRzCBSmRpJ/Pn33wpiYjs+9FB2E03svKaD04/lSSLlEUej0UYsugfg=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -1806,8 +1806,6 @@
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "copy-anything/is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
-
-    "croct-nanostores/@inox-tools/utils": ["@inox-tools/utils@0.8.1", "", {}, "sha512-SGjdzPcxJn6UOpSuxdg8Vm5s22EWhd4HSNWLymiN35+KbnoX3sgwoQMW4a6Zcv/HWdyZezl4Q7WUtZnt+UCuHw=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,14 @@
       "dependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
+        "@inox-tools/utils": "^1.0.0",
+        "@types/bun": "^1.3.9",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
         "turbo": "^2.8.3",
+        "typescript": "^5.9.3",
       },
     },
     "docs": {
@@ -51,6 +54,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@croct/json": "^2.1.0",
+        "@inox-tools/utils": "^0.8.1",
         "@nanostores/persistent": "^1.3.3",
         "nanostores": "^1.1.0",
       },
@@ -355,6 +359,8 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@inox-tools/utils": ["@inox-tools/utils@1.0.0", "", { "peerDependencies": { "nanostores": "^1.1.0" }, "optionalPeers": ["nanostores"] }, "sha512-3WKDWCzMdzGcMmthYWo5FRaD+AFdaOtcbj5tqgGAnUdCFhnHoiVaZgEGM+AYlSTDGuFBhAIAPDLK0AN3xLJGXQ=="],
+
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
@@ -529,6 +535,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
@@ -690,6 +698,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -1796,6 +1806,8 @@
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "copy-anything/is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
+
+    "croct-nanostores/@inox-tools/utils": ["@inox-tools/utils@0.8.1", "", {}, "sha512-SGjdzPcxJn6UOpSuxdg8Vm5s22EWhd4HSNWLymiN35+KbnoX3sgwoQMW4a6Zcv/HWdyZezl4Q7WUtZnt+UCuHw=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 

--- a/docs/src/content/docs/api-reference.mdx
+++ b/docs/src/content/docs/api-reference.mdx
@@ -91,11 +91,11 @@ Additional options passed to the underlying [`croct.fetch()`](https://docs.croct
 
 Commonly used options include:
 
-| Option            | Type     | Description                                                                                                                                               |
-| ----------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `timeout`         | `number` | Maximum time in milliseconds to wait for a response. Setting this also disables [localStorage persistence](/content-rendering#opting-out-of-persistence). |
-| `preferredLocale` | `string` | The locale to use for content personalization (e.g., `'en-US'`).                                                                                          |
-| `attributes`      | `object` | Custom attributes to pass to the personalization engine.                                                                                                  |
+| Option            | Type                             | Description                                                                                                                                                                       |
+| ----------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeout`         | `number`                         | Maximum time in milliseconds to wait for a response. Setting this also disables [localStorage persistence](/content-rendering#opting-out-of-persistence).                         |
+| `preferredLocale` | `string \| ReadableAtom<string>` | The locale to use for content personalization (e.g., `'en-US'`). Can be a Nanostores atom for automatic refresh on locale changes.                                                |
+| `attributes`      | `object`                         | Custom attributes to pass to the personalization engine. Values at any nesting level can be Nanostores atoms — see [reactive attributes](/content-rendering#reactive-attributes). |
 
 For the full list of supported options, see the [`croct.fetch()` reference](https://docs.croct.com/reference/sdk/javascript/api/plug/fetch).
 
@@ -105,6 +105,45 @@ const banner = croctContent('home-banner@1', fallback, {
     preferredLocale: 'pt-BR',
 });
 ```
+
+#### Reactive attributes
+
+The `attributes` option supports Nanostores atoms at any level of the object tree. When any embedded atom updates, the content automatically refreshes with the resolved values:
+
+```ts
+import { atom } from 'nanostores';
+import { croctContent } from 'croct-nanostores';
+
+const $currency = atom('USD');
+
+const banner = croctContent('home-banner@1', fallback, {
+    attributes: { currency: $currency },
+});
+
+// Updating the atom triggers a content refresh
+$currency.set('BRL');
+```
+
+You can also wrap the entire attributes object in an atom, or nest atoms arbitrarily deep — all of these are equivalent in behavior:
+
+```ts
+// Atom at the root
+croctContent('slot@1', fallback, {
+    attributes: atom({ currency: 'USD' }),
+});
+
+// Atom on a leaf value
+croctContent('slot@1', fallback, {
+    attributes: { currency: atom('USD') },
+});
+
+// Atom nested deeper
+croctContent('slot@1', fallback, {
+    attributes: { user: { currency: atom('USD') } },
+});
+```
+
+Passing a plain object with no atoms still works exactly as before. See [reactive attributes](/content-rendering#reactive-attributes) for a detailed explanation of the behavior.
 
 ### Return value
 

--- a/docs/src/content/docs/content-rendering.mdx
+++ b/docs/src/content/docs/content-rendering.mdx
@@ -173,6 +173,82 @@ Only atoms that are currently mounted (subscribed to by at least one component) 
 
 This means you don't pay for refreshing content that isn't being displayed.
 
+## Reactive attributes
+
+The `attributes` option on `croctContent` supports Nanostores atoms at any level of the object tree, and `preferredLocale` accepts a `ReadableAtom<string>` in addition to a plain string. The library recursively resolves all atoms and subscribes to them — whenever any embedded atom updates, the content automatically refreshes with the resolved values. This lets you tie individual personalization parameters to reactive application state without manually calling `refresh()`.
+
+```ts title="src/stores/banner.ts"
+import { atom } from 'nanostores';
+import { croctContent } from 'croct-nanostores';
+
+const $currency = atom('USD');
+const $segment = atom('returning');
+
+export const bannerContent = croctContent(
+    'home-banner@1',
+    {
+        title: 'Welcome',
+        subtitle: 'Explore our latest collection',
+        ctaLabel: 'Shop now',
+        ctaLink: '/products',
+    },
+    {
+        attributes: {
+            currency: $currency,
+            segment: $segment,
+        },
+    },
+);
+```
+
+When either atom is updated, the content refreshes with the new resolved attributes:
+
+```ts
+// The banner automatically refreshes with the new currency
+$currency.set('BRL');
+```
+
+Atoms can appear at any nesting level — at the root wrapping the entire object, on individual leaf values, or nested arbitrarily deep:
+
+```ts
+// Atom at the root
+croctContent('slot@1', fallback, {
+    attributes: atom({ currency: 'USD' }),
+});
+
+// Atom on a leaf value
+croctContent('slot@1', fallback, {
+    attributes: { currency: atom('USD') },
+});
+
+// Atom nested deeper
+croctContent('slot@1', fallback, {
+    attributes: { user: { currency: atom('USD') } },
+});
+```
+
+### How it works
+
+Internally, the library wraps the `attributes` value with a resolved atom that recursively walks the object tree, resolves every Nanostores atom it finds, and subscribes to all of them. The resulting flat object is passed to `croct.fetch()`. If you pass a plain object with no atoms, it behaves as a static value — attributes are sent with every fetch but don't trigger refreshes on their own.
+
+On each change, the library compares the new resolved attributes with the last fetched attributes by reference. If they are the same object, the fetch is skipped. This means the refresh only fires when an embedded atom produces a new value.
+
+:::tip
+Reactive attributes compose naturally with [auto-refresh](#auto-refresh). When both are enabled, content refreshes on attribute changes _and_ on user behavior events, giving you full coverage without any manual wiring.
+:::
+
+### When to use reactive attributes
+
+Use a Nanostores atom for `attributes` when the attributes depend on application state that can change during the user's session:
+
+- **Currency or region picker** — fetch region-specific personalization
+- **Locale selector** — pass a reactive `preferredLocale` atom and content refreshes when the user switches languages
+- **A/B test flags** — pass experiment assignments that may change at runtime
+- **User segments** — adjust content based on dynamic audience classification
+- **Derived state** — use a [computed atom](https://github.com/nanostores/nanostores#computed-stores) to combine multiple stores into a single attributes object
+
+For attributes that are static for the lifetime of the page (like a page ID or a hardcoded segment), a plain object is simpler and works just as well.
+
 ## Manual refresh
 
 Every atom exposes a `refresh()` method that returns a promise. You can call it to force a fresh fetch from Croct at any time:

--- a/package.json
+++ b/package.json
@@ -32,11 +32,14 @@
     "dependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
+        "@inox-tools/utils": "^1.0.0",
+        "@types/bun": "^1.3.9",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
-        "turbo": "^2.8.3"
+        "turbo": "^2.8.3",
+        "typescript": "^5.9.3"
     },
     "patchedDependencies": {
         "astro-live-code@0.0.6": "patches/astro-live-code@0.0.6.patch"

--- a/package/build.ts
+++ b/package/build.ts
@@ -1,7 +1,6 @@
-import { readFileSync, rmSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
 
-const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+const packageJson = await Bun.file('./package.json').json();
 const external = [
     ...Object.keys(packageJson.dependencies ?? {}),
     ...Object.keys(packageJson.peerDependencies ?? {}),
@@ -35,4 +34,5 @@ for (const output of result.outputs) {
     console.log(`  ${output.path} (${output.size} bytes)`);
 }
 
-execSync('tsc --project tsconfig.build.json', { stdio: 'inherit' });
+const res = await Bun.$`tsc --project tsconfig.build.json`.nothrow();
+process.exit(res.exitCode);

--- a/package/package.json
+++ b/package/package.json
@@ -51,7 +51,7 @@
     },
     "dependencies": {
         "@croct/json": "^2.1.0",
-        "@inox-tools/utils": "^0.8.1",
+        "@inox-tools/utils": "^1.0.0",
         "@nanostores/persistent": "^1.3.3",
         "nanostores": "^1.1.0"
     },

--- a/package/package.json
+++ b/package/package.json
@@ -51,6 +51,7 @@
     },
     "dependencies": {
         "@croct/json": "^2.1.0",
+        "@inox-tools/utils": "^0.8.1",
         "@nanostores/persistent": "^1.3.3",
         "nanostores": "^1.1.0"
     },


### PR DESCRIPTION
## Summary

- Add support for using Nanostores atoms inside the `attributes` option at any nesting level — root, leaf, or arbitrarily deep. Slot content automatically refreshes whenever any embedded atom updates.
- Allow `preferredLocale` to accept a `ReadableAtom<string>` in addition to a plain string, with the same auto-refresh behavior.
- Document both features in the API reference, content rendering guide, and README.

## Changes

### Library (`package/src/croctAtom.ts`)
- Wrap both `attributes` and `preferredLocale` with `resolvedAtom` from `@inox-tools/utils/nano` to recursively resolve atoms at any depth
- Accept `ReadableAtom<string>` as `preferredLocale` type

### Documentation
- **API reference**: Updated `attributes` and `preferredLocale` option descriptions, added "Reactive attributes" subsection with examples
- **Content rendering guide**: Added full "Reactive attributes" section with usage examples, nesting patterns, and "How it works" explanation
- **README**: Added reactive attributes to the feature list

### Changeset
- Minor version bump for `croct-nanostores`