### PR TITLE
test: add coverage for auto patching

### DIFF
--- a/.changeset/soft-doors-hang.md
+++ b/.changeset/soft-doors-hang.md
@@ -1,0 +1,5 @@
+---
+'croct-nanostores': minor
+---
+
+Add helpers to sync Nanostores values into Croct session and user fields, batching updates into a single patch per tick.

--- a/docs/src/content/docs/api-reference.mdx
+++ b/docs/src/content/docs/api-reference.mdx
@@ -3,10 +3,16 @@ title: API reference
 description: Complete reference for the Croct Nanostores public API — functions, types, and options.
 ---
 
-Croct Nanostores exports three members from the `croct-nanostores` package:
+Croct Nanostores exports five members from the `croct-nanostores` package:
 
 ```ts
-import { croct, croctContent, type CroctAtom } from 'croct-nanostores';
+import {
+    croct,
+    croctContent,
+    trackSessionField,
+    trackUserField,
+    type CroctAtom,
+} from 'croct-nanostores';
 ```
 
 ## `croct`
@@ -218,6 +224,88 @@ const state = useStore(bannerContent);
 
 // Svelte
 $bannerContent.content.title;
+```
+
+## `trackSessionField`
+
+Connects a Nanostores atom to a Croct session field. When the atom updates, the new value is batched and sent to Croct through `croct.session.edit()`. Multiple tracked fields are collapsed into a single patch per tick.
+
+### Signature
+
+```ts
+function trackSessionField(path: string, atom: ReadableAtom<JsonValue>): UnbindFn;
+```
+
+### Parameters
+
+#### `path`
+
+**Type:** `string`
+
+The Croct session field path to update. Use dot notation for nested fields.
+
+#### `atom`
+
+**Type:** `ReadableAtom<JsonValue>`
+
+The Nanostores atom whose value should be pushed to the session field.
+
+### Return value
+
+Returns an `UnbindFn` that stops the synchronization when called.
+
+### Example
+
+```ts
+import { atom } from 'nanostores';
+import { trackSessionField } from 'croct-nanostores';
+
+const $cartTotal = atom(120);
+const stop = trackSessionField('cart.total', $cartTotal);
+
+// Later, when you no longer want to sync
+stop();
+```
+
+## `trackUserField`
+
+Connects a Nanostores atom to a Croct user field. Updates are batched and sent to Croct through `croct.user.edit()`.
+
+### Signature
+
+```ts
+function trackUserField(path: string, atom: ReadableAtom<JsonValue>): UnbindFn;
+```
+
+### Parameters
+
+#### `path`
+
+**Type:** `string`
+
+The Croct user field path to update. Use dot notation for nested fields.
+
+#### `atom`
+
+**Type:** `ReadableAtom<JsonValue>`
+
+The Nanostores atom whose value should be pushed to the user field.
+
+### Return value
+
+Returns an `UnbindFn` that stops the synchronization when called.
+
+### Example
+
+```ts
+import { atom } from 'nanostores';
+import { trackUserField } from 'croct-nanostores';
+
+const $plan = atom('pro');
+const stop = trackUserField('account.plan', $plan);
+
+// Later, when you no longer want to sync
+stop();
 ```
 
 ## `State`

--- a/docs/src/content/docs/api-reference.mdx
+++ b/docs/src/content/docs/api-reference.mdx
@@ -260,8 +260,8 @@ Returns an `UnbindFn` that stops the synchronization when called.
 import { atom } from 'nanostores';
 import { trackSessionField } from 'croct-nanostores';
 
-const $cartTotal = atom(120);
-const stop = trackSessionField('cart.total', $cartTotal);
+const $currency = atom('USD');
+const stop = trackSessionField('preferences.currency', $currency);
 
 // Later, when you no longer want to sync
 stop();

--- a/package/.size-limit.json
+++ b/package/.size-limit.json
@@ -2,19 +2,31 @@
     {
         "name": "Full with all deps",
         "path": "dist/index.js",
-        "import": "{ croctContent }",
+        "import": "*",
         "ignore": []
     },
     {
         "name": "Already using Croct",
         "path": "dist/index.js",
-        "import": "{ croctContent }",
+        "import": "*",
         "ignore": ["@croct/plug"]
     },
     {
         "name": "Already using Nanostores",
         "path": "dist/index.js",
+        "import": "*",
+        "ignore": ["@croct/plug", "nanostores", "@nanostores/persistent"]
+    },
+    {
+        "name": "Content only",
+        "path": "dist/index.js",
         "import": "{ croctContent }",
+        "ignore": ["@croct/plug", "nanostores", "@nanostores/persistent"]
+    },
+    {
+        "name": "Tracking only",
+        "path": "dist/index.js",
+        "import": "{ trackSessionField, trackUserField }",
         "ignore": ["@croct/plug", "nanostores", "@nanostores/persistent"]
     }
 ]

--- a/package/src/autoPatching.ts
+++ b/package/src/autoPatching.ts
@@ -1,0 +1,42 @@
+import croct from '@croct/plug';
+import type { JsonValue } from '@croct/json';
+import type { ReadableAtom } from 'nanostores';
+import type { UnbindFn } from './common.js';
+
+/*#__PURE__*/
+function accumulateAndSend(
+    sendFn: (pairs: [string, JsonValue][]) => void,
+): (path: string, atom: ReadableAtom<JsonValue>) => UnbindFn {
+    const pendingPairs = new Map<string, JsonValue>();
+    let pendingTimer: ReturnType<typeof setTimeout> | undefined;
+    const send = () => {
+        const entries = Array.from(pendingPairs.entries());
+        pendingPairs.clear();
+        sendFn(entries);
+    };
+    return (path, atom) =>
+        atom.subscribe(value => {
+            // Cast to remove the read-only marker.
+            pendingPairs.set(path, value as JsonValue);
+            clearTimeout(pendingTimer);
+            pendingTimer = setTimeout(send);
+        });
+}
+
+/*#__PURE__*/
+export const trackSessionField = accumulateAndSend(pairs => {
+    const patch = croct.session.edit();
+    for (const [path, value] of pairs) {
+        patch.set(path, value);
+    }
+    patch.save();
+});
+
+/*#__PURE__*/
+export const trackUserField = accumulateAndSend(pairs => {
+    const patch = croct.user.edit();
+    for (const [path, value] of pairs) {
+        patch.set(path, value);
+    }
+    patch.save();
+});

--- a/package/src/common.ts
+++ b/package/src/common.ts
@@ -1,0 +1,1 @@
+export type UnbindFn = () => void;

--- a/package/src/croctAtom.ts
+++ b/package/src/croctAtom.ts
@@ -36,6 +36,7 @@ type Options<P extends JsonObject, I extends VersionedSlotId> = Omit<
 
 const activeAtoms = new Set<CroctAtom<any, any>>();
 
+/*#__PURE__*/
 export function croctContent<P extends JsonObject, const I extends VersionedSlotId>(
     slotId: I,
     fallbackContent: SlotContent<I, P>,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,5 +1,6 @@
 import './croctPlugin.js';
 import croct from '@croct/plug';
 import { type CroctAtom, croctContent } from './croctAtom.js';
+export { trackSessionField, trackUserField } from './autoPatching.js';
 
 export { croct, croctContent, type CroctAtom };

--- a/package/test/autoPatching.test.ts
+++ b/package/test/autoPatching.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReadableAtom } from 'nanostores';
+
+const sessionEdit = vi.hoisted(() => vi.fn());
+const userEdit = vi.hoisted(() => vi.fn());
+
+vi.mock('@croct/plug', () => ({
+    default: {
+        session: {
+            edit: sessionEdit,
+        },
+        user: {
+            edit: userEdit,
+        },
+    },
+}));
+
+const createReadableAtom = <T>(initial: T) => {
+    let value = initial;
+    const listeners = new Set<(next: T) => void>();
+
+    return {
+        subscribe: (listener: (next: T) => void) => {
+            listeners.add(listener);
+            listener(value);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        set: (next: T) => {
+            value = next;
+            for (const listener of listeners) {
+                listener(value);
+            }
+        },
+    } satisfies ReadableAtom<T> & { set: (next: T) => void };
+};
+
+async function flushTimers() {
+    await Promise.resolve();
+    vi.runOnlyPendingTimers();
+    await Promise.resolve();
+}
+
+describe('auto patching', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        sessionEdit.mockReset();
+        userEdit.mockReset();
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    it('batches multiple session fields into a single patch', async () => {
+        const { trackSessionField } = await import('../src/autoPatching.js');
+        const patch = { set: vi.fn(), save: vi.fn() };
+        sessionEdit.mockReturnValue(patch);
+
+        const total = createReadableAtom(120);
+        const currency = createReadableAtom('USD');
+
+        trackSessionField('cart.total', total);
+        trackSessionField('cart.currency', currency);
+
+        await flushTimers();
+
+        expect(sessionEdit).toHaveBeenCalledTimes(1);
+        expect(patch.set).toHaveBeenCalledWith('cart.total', 120);
+        expect(patch.set).toHaveBeenCalledWith('cart.currency', 'USD');
+        expect(patch.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the latest value for repeated updates', async () => {
+        const { trackSessionField } = await import('../src/autoPatching.js');
+        const patch = { set: vi.fn(), save: vi.fn() };
+        sessionEdit.mockReturnValue(patch);
+
+        const total = createReadableAtom(100);
+        trackSessionField('cart.total', total);
+
+        await flushTimers();
+        patch.set.mockClear();
+        patch.save.mockClear();
+        sessionEdit.mockClear();
+
+        total.set(110);
+        total.set(115);
+
+        await flushTimers();
+
+        const latestPatch = sessionEdit.mock.results[0]?.value as typeof patch;
+        expect(latestPatch.set).toHaveBeenCalledTimes(1);
+        expect(latestPatch.set).toHaveBeenCalledWith('cart.total', 115);
+        expect(latestPatch.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops tracking when unsubscribed', async () => {
+        const { trackSessionField } = await import('../src/autoPatching.js');
+        const patch = { set: vi.fn(), save: vi.fn() };
+        sessionEdit.mockReturnValue(patch);
+
+        const total = createReadableAtom(100);
+        const unsubscribe = trackSessionField('cart.total', total);
+
+        await flushTimers();
+        sessionEdit.mockClear();
+        patch.set.mockClear();
+        patch.save.mockClear();
+
+        unsubscribe();
+        total.set(200);
+
+        await flushTimers();
+
+        expect(sessionEdit).not.toHaveBeenCalled();
+        expect(patch.set).not.toHaveBeenCalled();
+        expect(patch.save).not.toHaveBeenCalled();
+    });
+
+    it('patches user fields with croct.user.edit()', async () => {
+        const { trackUserField } = await import('../src/autoPatching.js');
+        const patch = { set: vi.fn(), save: vi.fn() };
+        userEdit.mockReturnValue(patch);
+
+        const name = createReadableAtom('Luiz');
+        trackUserField('profile.name', name);
+
+        await flushTimers();
+
+        expect(userEdit).toHaveBeenCalledTimes(1);
+        expect(patch.set).toHaveBeenCalledWith('profile.name', 'Luiz');
+        expect(patch.save).toHaveBeenCalledTimes(1);
+    });
+});

--- a/package/test/croctAtom.test.ts
+++ b/package/test/croctAtom.test.ts
@@ -119,7 +119,10 @@ describe('croctContent', () => {
         const atom = croctContent('home-banner@1', fallback);
         await atom.refresh();
 
-        expect(croctFetch).toHaveBeenCalledWith('home-banner@1', undefined);
+        expect(croctFetch).toHaveBeenCalledWith('home-banner@1', {
+            attributes: undefined,
+            preferredLocale: undefined,
+        });
         expect(atom.value).toEqual({ stage: 'loaded', content: loaded, metadata });
     });
 


### PR DESCRIPTION
## Summary
- add tests for auto patching helpers and refresh expectations
- document trackSessionField/trackUserField in the API reference
- add a changeset for the new auto patching feature

## Testing
- npm run -w croct-nanostores test -- test/autoPatching.test.ts test/croctAtom.test.ts